### PR TITLE
fix: tenant namespaces namespace label definition

### DIFF
--- a/charts/tenant-namespaces/Chart.yaml
+++ b/charts/tenant-namespaces/Chart.yaml
@@ -4,6 +4,6 @@ description: A multi-tenant onboarding chart that automates namespace creation, 
 
 type: application
 
-version: 1.2.0
+version: 1.2.1
 
-appVersion: "1.2.0"
+appVersion: "1.2.1"

--- a/charts/tenant-namespaces/ci/minimal-extended-values.yaml
+++ b/charts/tenant-namespaces/ci/minimal-extended-values.yaml
@@ -1,3 +1,8 @@
+defaults:
+  namespace:
+    labels:
+      access.networking.openshift.io/default: ""
+
 project:
   name: "example-project"
   enabled: true
@@ -17,8 +22,7 @@ project:
         - p, proj:example-project:example-role, applications, get, example-namespace/*, allow
 
 namespaces:
-  - name: example-namespace
-    extraResources:
+  - extraResources:
       - apiVersion: v1
         kind: Secret
         metadata:

--- a/charts/tenant-namespaces/templates/_helpers.tpl
+++ b/charts/tenant-namespaces/templates/_helpers.tpl
@@ -47,7 +47,9 @@ Custom labels for OpenShift monitoring
 {{- if .features.enableUserMonitoring }}
 openshift.io/user-monitoring: "true"
 {{- end }}
-{{- .labels | toYaml | nindent 0 }}
+{{- with .labels }}
+{{- . | toYaml | nindent 0 }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/tenant-namespaces/templates/_helpers.tpl
+++ b/charts/tenant-namespaces/templates/_helpers.tpl
@@ -47,9 +47,7 @@ Custom labels for OpenShift monitoring
 {{- if .features.enableUserMonitoring }}
 openshift.io/user-monitoring: "true"
 {{- end }}
-{{- range $k, $v := .labels }}
-{{ $k }}: {{ $v }}
-{{- end }}
+{{- .labels | toYaml | nindent 0 }}
 {{- end }}
 
 {{/*

--- a/charts/tenant-namespaces/templates/namespace.yaml
+++ b/charts/tenant-namespaces/templates/namespace.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ $mergedData.name | quote }}
+  name: {{ $mergedData.name | quote | required "Namespace name is required" }}
   {{- with (include "tenant-namespaces.custom-labels" $mergedData) }}
   labels:
     {{- . | nindent 4 }}


### PR DESCRIPTION
Fix label definition for namespaces.

## Before the change:

```
defaults:
  namespace:
    labels:
      abc: ""
      some.label.com/second: "true"
```

Namespace:

```
---
# Source: tenant-namespaces/templates/namespace.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: "abc"
  labels:
    some.label.com/default:
    some.label.com/second: true
```

## After the change:

```
defaults:
  namespace:
    labels:
      abc: ""
      some.label.com/second: "true"
```

Namespace:

```
---
# Source: tenant-namespaces/templates/namespace.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: "abc"
  labels:
    some.label.com/default: ""
    some.label.com/second: "true"
```